### PR TITLE
絵文字入力フォームの結果がおかしくなるバグを修正

### DIFF
--- a/lib/emoji/emoji_picker.dart
+++ b/lib/emoji/emoji_picker.dart
@@ -104,7 +104,13 @@ class _EmojiPickerState extends State<EmojiPicker> {
         Padding(
           padding: const EdgeInsets.all(8),
           child: ElevatedButton(
-            onPressed: () => Navigator.pop(context, emojiSubject.value),
+            onPressed: () {
+              final parseResult = parseEmoji(emojiSubject.value);
+              final result =
+                  parseResult.isNotEmpty ? parseResult : emojiSubject.value;
+
+              Navigator.pop(context, result);
+            },
             child: const Text('選択'),
           ),
         ),


### PR DESCRIPTION
`:sushi:` を打って選択ボタンを押したときに🍣の絵文字じゃなくて `:sushi:` が表示されちゃうバグを直した。
(なんで気づかなかったんだろ??? 🤔 )