### PR TITLE
絵文字選択画面の絵文字の描画方法を修正

### DIFF
--- a/lib/emoji/emoji_picker.dart
+++ b/lib/emoji/emoji_picker.dart
@@ -130,7 +130,7 @@ class _EmojiPickerState extends State<EmojiPicker> {
           child: ListTile(
             leading: NativeEmojiView(
               emoji: data.emoji,
-              capturable: false,
+              capturable: true,
               size: 32,
             ),
             title: Text(data.name),


### PR DESCRIPTION
チラツキが発生していたため。